### PR TITLE
Renaming Object Type motor_bike to motorbike

### DIFF
--- a/osi_object.proto
+++ b/osi_object.proto
@@ -85,7 +85,7 @@ message Vehicle
         
         // Vehicle is a motorbike or moped.
         //
-        TYPE_MOTOR_BIKE = 4;
+        TYPE_MOTORBIKE = 4;
         
         // Vehicle is a bicycle (without motor).
         //


### PR DESCRIPTION
According to many dictionaries, the Object Type "motor_bike" should be renamed to "motorbike"

See: https://dictionary.cambridge.org/dictionary/english-german/motorbike and
https://de.pons.com/%C3%BCbersetzung?q=motorbike&l=deen&in=&lf=de

Let me know when there are other reasons for keeping "motor_bike"!

